### PR TITLE
Fix lint errors and set up secrets.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,5 @@
+AllCops:
+  TargetRubyVersion: 2.4
+  Exclude:
+    - db/**/*
+    - bin/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -2,37 +2,37 @@ ruby File.read(".ruby-version").strip
 
 source "https://rubygems.org"
 
-gem "rails", "5.2.0"
+gem "addressable"
 gem "bootsnap"
-
 gem "database_cleaner"
 gem "deprecated_columns"
+gem "gds-api-adapters"
 gem "gds-sso"
-gem "plek"
+gem "govuk-content-schema-test-helpers"
 gem "govuk_app_config"
+gem "govuk_sidekiq"
+gem "plek"
+gem "rails", "5.2.0"
 gem "sass-rails"
 gem "uglifier"
-gem "gds-api-adapters"
-gem "govuk_sidekiq"
-gem "addressable"
-gem "govuk-content-schema-test-helpers"
+
 group :development, :test do
-  gem "poltergeist"
+  gem "byebug" # Comes standard with Rails
   gem "capybara"
-  gem "pry"
-  gem "simplecov-rcov", require: false
-  gem "simplecov", require: false
-  gem "govuk-lint"
-  gem "sqlite3" # Remove this when you choose a production database
   gem "factory_bot_rails"
+  gem "govuk-lint"
+  gem "poltergeist"
+  gem "pry"
+  gem "rspec-rails"
+  gem "simplecov", require: false
+  gem "simplecov-rcov", require: false
+  gem "sqlite3" # Remove this when you choose a production database
   gem "timecop"
   gem "webmock", require: false
-  gem "rspec-rails"
-  gem "byebug" # Comes standard with Rails
 end
 
 group :development do
+  gem "listen"
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem "web-console"
-  gem "listen"
 end

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,5 +3,5 @@
 library("govuk")
 
 node {
-  govuk.buildProject()
+  govuk.buildProject(rubyLintDiff: false)
 }

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -1,3 +1,4 @@
+// scss-lint:disable Comment
 /*
  * This is a manifest file that'll be compiled into application.css, which will include all the files
  * listed below.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,5 @@
 class ApplicationController < ActionController::Base
   include GDS::SSO::ControllerMethods
 
-  before_action :authenticate_user!!
-
+  before_action :authenticate_user!
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,7 @@ module OrganisationsPublisher
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    config.require_master_key = false
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -53,7 +53,7 @@ Rails.application.configure do
   config.log_level = :debug
 
   # Prepend all log lines with the following tags.
-  config.log_tags = [ :request_id ]
+  config.log_tags = [:request_id]
 
   # Use a different cache store in production.
   # config.cache_store = :mem_cache_store

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -1,0 +1,22 @@
+# Be sure to restart your server when you modify this file.
+
+# Your secret key is used for verifying the integrity of signed cookies.
+# If you change this key, all old signed cookies will become invalid!
+
+# Make sure the secret is at least 30 characters and all random,
+# no regular words or you'll be exposed to dictionary attacks.
+# You can use `rails secret` to generate a secure secret key.
+
+# Make sure the secrets in this file are kept private
+# if you're sharing your code publicly.
+
+development:
+  secret_key_base: a43a629bf5abbaa4e1b92d32fddc0cbb56b1071cbef0c7e5eef18acb0e5e9581af6631d1e0e6b41d49fd3609e552e52325bf1b3f494ec26114ea81a121225d26
+
+test:
+  secret_key_base: 90674c85dcb923963e4b34f4ff33cc23d56c3fd252d92c89299d7cd6fa5f48eb2edc3e8ded366159048805d53f139ccec19d15e6b59276f7dabc826ed3411f1f
+
+# Do not keep production secrets in the repository,
+# instead read values from the environment.
+production:
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -38,7 +38,7 @@ RSpec.configure do |config|
     GDS::SSO.test_user = nil
   end
 
-  [:controller, :request].each do |spec_type|
+  %i(controller request).each do |spec_type|
     config.before :each, type: spec_type do
       login_as_stub_user
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
-  require "pry"
-  require "byebug"
+require "pry"
+require "byebug"
 require "webmock"
 require "timecop"
 


### PR DESCRIPTION
This PR:

* Fixes all linting errors
* Sets the `secret_key_base` using `secrets.yml` rather than the new Rails 5.2 credentials system