### PR TITLE
Remove poltergeist as it's not used in test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,6 @@ group :development, :test do
   gem "capybara"
   gem "factory_bot_rails"
   gem "govuk-lint"
-  gem "poltergeist"
   gem "pry"
   gem "rspec-rails"
   gem "simplecov", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,6 @@ GEM
       rack (>= 1.6.0)
       rack-test (>= 0.6.3)
       xpath (~> 3.0)
-    cliver (0.3.2)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.1)
@@ -186,10 +185,6 @@ GEM
       ast (~> 2.4.0)
     pg (1.0.0)
     plek (2.1.1)
-    poltergeist (1.18.0)
-      capybara (>= 2.1, < 4)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.11.3)
       coderay (~> 1.1.0)
@@ -367,7 +362,6 @@ DEPENDENCIES
   listen
   pg
   plek
-  poltergeist
   pry
   rails (= 5.2.0)
   rspec-rails
@@ -384,4 +378,4 @@ RUBY VERSION
    ruby 2.4.4p296
 
 BUNDLED WITH
-   1.16.1
+   1.16.2


### PR DESCRIPTION
https://trello.com/c/0QzuQFMb/415-epic-switch-app-test-suites-from-poltergeist-to-headless-chrome-using-govuktest

Poltergeist isn't maintained, and it's not used in this project.